### PR TITLE
Add --version flag to CLI

### DIFF
--- a/macos_trust/cli.py
+++ b/macos_trust/cli.py
@@ -16,6 +16,8 @@ from macos_trust.vendors import KNOWN_VENDORS
 from macos_trust.config import Config, load_config, save_example_config
 from macos_trust.baseline import Baseline
 
+__version__ = "0.4.0"
+
 
 def scan(
     json: bool = typer.Option(
@@ -314,7 +316,29 @@ def scan(
 
 def main() -> None:
     """Entry point for the CLI."""
-    typer.run(scan)
+    app = typer.Typer(add_completion=False)
+    app.command()(scan)
+    
+    def version_callback(value: bool):
+        if value:
+            typer.echo(f"macos-trust version {__version__}")
+            raise typer.Exit()
+    
+    @app.callback()
+    def common(
+        version: Optional[bool] = typer.Option(
+            None,
+            "--version",
+            "-v",
+            callback=version_callback,
+            is_eager=True,
+            help="Show version and exit"
+        )
+    ):
+        """macOS Trust Scanner - Intelligent security scanning for macOS systems."""
+        pass
+    
+    app()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Add a `--version` flag to the command-line interface to display the current version of the application.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Related Issues
Fixes #

## Changes Made
- Introduced a `--version` flag that outputs the application version.
- Updated the CLI entry point to accommodate the new flag.